### PR TITLE
Rename 'message' variable to 'output' for consistency

### DIFF
--- a/Devantler.KubectlCLI.Tests/KubectlTests/RunAsyncTests.cs
+++ b/Devantler.KubectlCLI.Tests/KubectlTests/RunAsyncTests.cs
@@ -13,11 +13,11 @@ public class RunAsyncTests
   public async Task RunAsync_Version_ReturnsVersion()
   {
     // Act
-    var (exitCode, message) = await Kubectl.RunAsync(["version", "--client"]);
+    var (exitCode, output) = await Kubectl.RunAsync(["version", "--client"]);
 
     // Assert
     Assert.Equal(0, exitCode);
     // Client Version: v1.32.0
-    Assert.Matches(@"^Client Version: v\d+\.\d+\.\d+$", message.Split(Environment.NewLine).First());
+    Assert.Matches(@"^Client Version: v\d+\.\d+\.\d+$", output.Split(Environment.NewLine).First());
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ You can execute the Kubectl CLI commands using the `Kubectl` class.
 ```csharp
 using Devantler.KubectlCLI;
 
-var (exitCode, message) = await Kubectl.RunAsync(["arg1", "arg2"]);
+var (exitCode, output) = await Kubectl.RunAsync(["arg1", "arg2"]);
 ```


### PR DESCRIPTION
Update variable naming in the RunAsync method to improve consistency across the codebase.